### PR TITLE
Fix deprecation: import persistent_notification and use it directly

### DIFF
--- a/custom_components/authenticated/sensor.py
+++ b/custom_components/authenticated/sensor.py
@@ -16,6 +16,7 @@ from ipaddress import ip_network
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 import yaml
+from homeassistant.components import persistent_notification
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 
@@ -459,7 +460,7 @@ class IPData:
 
     def notify(self, hass):
         """Create persistant notification."""
-        notify = hass.components.persistent_notification.create
+        notify = persistent_notification.create
         message = f"""
         **IP Address:**   {self.ip_address}
         **Username:**    {self.username}
@@ -479,4 +480,4 @@ class IPData:
         if self.last_used_at is not None:
             message += f"**Login time:**   {self.last_used_at[:19].replace('T', ' ')}"
 
-        notify(message, title="New successful login", notification_id=self.ip_address)
+        notify(hass, message, title="New successful login", notification_id=self.ip_address)


### PR DESCRIPTION
See also home-assistant/core#63901. This avoids the below deprecation:

```
Detected that custom integration 'authenticated' accesses hass.components.persistent_notification which should be updated to import functions used from persistent_notification directly at custom_components/authenticated/sensor.py, line XYZ: hass.components.persistent_notification.create(
This will stop working in Home Assistant 2025.3, please report it to the author of the 'authenticated' custom integration
```

Tested: login notifications still appear as expected