### PR TITLE
Using async_create instead of deprecated persistent_notification 

### DIFF
--- a/custom_components/authenticated/providers.py
+++ b/custom_components/authenticated/providers.py
@@ -70,8 +70,7 @@ class GeoProvider:
         self.result = {}
         try:
             api = self.url.format(self.ipaddr)
-            header = {"user-agent": "Home Assistant/Python"}
-            data = requests.get(api, headers=header, timeout=5).json()
+            data = requests.get(api, timeout=5).json()
 
             _LOGGER.debug(data)
 

--- a/custom_components/authenticated/sensor.py
+++ b/custom_components/authenticated/sensor.py
@@ -16,6 +16,7 @@ from ipaddress import ip_network
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 import yaml
+from homeassistant.components.persistent_notification import async_create
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 
@@ -459,7 +460,6 @@ class IPData:
 
     def notify(self, hass):
         """Create persistant notification."""
-        notify = hass.components.persistent_notification.create
         message = f"""
         **IP Address:**   {self.ip_address}
         **Username:**    {self.username}
@@ -479,4 +479,4 @@ class IPData:
         if self.last_used_at is not None:
             message += f"**Login time:**   {self.last_used_at[:19].replace('T', ' ')}"
 
-        notify(message, title="New successful login", notification_id=self.ip_address)
+        async_create(hass, message, title="New successful login", notification_id=self.ip_address)


### PR DESCRIPTION
- `hass.components.persistent_notification.create` is deprecated and causes an error when used in the latest home assistant version
- Removing `user-agent` being passed when making the API request as it was causing rate limit errors all the time.