### PR TITLE
Fix async_dispatcher_send error in notifications

### DIFF
--- a/custom_components/authenticated/sensor.py
+++ b/custom_components/authenticated/sensor.py
@@ -251,7 +251,7 @@ class AuthenticatedSensor(Entity):
                         # Host name is in exclude list
                         pass
                     else:
-                        ipaddress.notify(self.hass)
+                        self.hass.add_job(ipaddress.notify, self.hass)
                 ipaddress.new_ip = False
 
             self.hass.data[PLATFORM_NAME][access] = ipaddress


### PR DESCRIPTION
(AI generated)

## Fix `async_dispatcher_send` thread-safety error

### Problem

`AuthenticatedSensor.update()` is executed by Home Assistant in an executor thread.

When a new IP address is detected, `update()` directly calls `IPData.notify()`. That method calls the async `persistent_notification.async_create()` API.

This causes Home Assistant to execute `async_dispatcher_send()` from outside the event-loop thread and results in:

`RuntimeError: Detected that integration 'persistent_notification' calls async_dispatcher_send from a thread other than the event loop`

This is reported in #13.

### Fix

Schedule `IPData.notify()` on the Home Assistant event loop using `hass.add_job()` instead of calling it directly from the executor thread.

Before:

```python
ipaddress.notify(self.hass)
```

After:

```python
self.hass.add_job(ipaddress.notify, self.hass)
```

This keeps `async_create()` on the correct Home Assistant event-loop thread while leaving the existing notification behavior unchanged.

Fixes #13.